### PR TITLE
Product Download & Release Channel Updates 

### DIFF
--- a/app/Http/Controllers/AutoUpdate/AutoUpdateController.php
+++ b/app/Http/Controllers/AutoUpdate/AutoUpdateController.php
@@ -63,9 +63,11 @@ class AutoUpdateController extends Controller
             $api_key_secret = $this->licenseService->getApiKeySecret();
             $token = $this->licenseService->getValidToken();
 
-            $addProduct = $this->postCurl($url.'api/admin/products/UpdateAdd', "api_key_secret=$api_key_secret&product_id=$product_id&product_title=$product_name&product_sku=$product_sku&product_key=$key&product_status=1", $token);
+            $this->postCurl($url.'api/admin/products/UpdateAdd', "api_key_secret=$api_key_secret&product_id=$product_id&product_title=$product_name&product_sku=$product_sku&product_key=$key&product_status=1", $token);
             //need to remove this once we deprecate updates.faveohelpdesk.com
-            $anotheradd = $this->postCurl($this->updateUrl, "api_key_secret=$this->update_api_secret&api_function=products_add&product_title=$product_name&product_sku=$product_sku&product_key=$key&product_status=1");
+            $this->postCurl($this->updateUrl, "api_key_secret=$this->update_api_secret&api_function=products_add&product_title=$product_name&product_sku=$product_sku&product_key=$key&product_status=1");
+
+            return $key;
         } catch (\Exception $ex) {
             throw new \Exception(__('message.configure_valid_license'));
         }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -333,7 +333,7 @@ class HomeController extends BaseHomeController
         try {
             $faveo_encrypted_order_number = $request->input('order_number');
             $faveo_serial_key = $request->input('serial_key');
-            $release  = $request->input('release', 'official');
+            $release = $request->input('release', 'official');
 
             $orderSerialKey = $order->where('number', $faveo_encrypted_order_number)
                 ->value('serial_key');

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -333,7 +333,7 @@ class HomeController extends BaseHomeController
         try {
             $faveo_encrypted_order_number = $request->input('order_number');
             $faveo_serial_key = $request->input('serial_key');
-            $beta = $request->input('beta', 1);
+            $release  = $request->input('release', 'official');
 
             $orderSerialKey = $order->where('number', $faveo_encrypted_order_number)
                 ->value('serial_key');
@@ -345,7 +345,7 @@ class HomeController extends BaseHomeController
                 $product_id = $this_order->product;
                 $product_controller = new \App\Http\Controllers\Product\ProductController();
 
-                return $product_controller->adminDownload($product_id, '', true, $beta);
+                return $product_controller->adminDownload($product_id, '', true, $release);
             } else {
                 return response()->json(['Invalid Credentials']);
             }

--- a/app/Http/Controllers/Order/OrderController.php
+++ b/app/Http/Controllers/Order/OrderController.php
@@ -545,7 +545,7 @@ class OrderController extends BaseOrderController
                             ->where('is_deleted', 1)
                             ->exists();
 
-                        if ($installation_path && ! $isCloudDeleted) {
+                        if ($installation_path && ! $isCloudDeleted && in_array($order->product, cloudPopupProducts())) {
                             event(new UserOrderDelete($installation_path, $order->id));
                         }
                         $order->delete();

--- a/app/Http/Controllers/Product/BaseProductController.php
+++ b/app/Http/Controllers/Product/BaseProductController.php
@@ -12,7 +12,6 @@ use App\Model\Product\ProductUpload;
 use App\ThirdPartyApp;
 use App\User;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class BaseProductController extends ExtendedBaseProductController
@@ -176,8 +175,6 @@ class BaseProductController extends ExtendedBaseProductController
             $this->checkSubscriptionExpiry($invoice);
             if ($user && $invoice) {
                 if ($user->active == 1) {
-                    $product_id = $invoice->order()->value('product');
-                    $name = Product::where('id', $product_id)->value('name');
                     $invoice_id = $invoice->id;
 
                     $release = $this->downloadProduct($uploadid, $userid, $invoice_id, $version_id);
@@ -187,28 +184,14 @@ class BaseProductController extends ExtendedBaseProductController
 
                         return view('themes.default1.front.download', compact('release'));
                     } else {
-                        if (isS3Enabled()) {
-                            if (! Attach::exists('products/'.explode('?', urldecode(basename($release)))[0])) {
-                                return redirect()->back()->with('fails', \Lang::get('message.file_not_exist'));
-                            }
-
-                            return downloadExternalFile($release, $name);
-                        } else {
-                            if (! $release instanceof \Symfony\Component\HttpFoundation\StreamedResponse) {
-                                return redirect()->back()->with('fails', \Lang::get('message.file_not_exist'));
-                            }
-                            $customFileName = "{$name}.zip";
-
-                            $release->headers->set(
-                                'Content-Disposition',
-                                $release->headers->makeDisposition(
-                                    ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                                    $customFileName
-                                )
-                            );
-
-                            return $release;
+                        // The stamping service always returns a local,
+                        // ready-to-send file response (S3 or not — the file
+                        // has to be copied and stamped locally either way).
+                        if (! $release instanceof \Symfony\Component\HttpFoundation\Response) {
+                            return redirect()->back()->with('fails', \Lang::get('message.file_not_exist'));
                         }
+
+                        return $release;
                     }
                 } else {
                     return redirect()->back()->with('fails', \Lang::get('activate-your-account'));
@@ -223,7 +206,7 @@ class BaseProductController extends ExtendedBaseProductController
         }
     }
 
-    public function getRelease($owner, $repository, $order_id, $file)
+    public function getRelease($owner, $repository, $order_id, $file, Product $product)
     {
         if ($owner && $repository) {//If the Product is downloaded from Github
             $github_controller = new \App\Http\Controllers\Github\GithubController();
@@ -232,14 +215,11 @@ class BaseProductController extends ExtendedBaseProductController
             return ['release' => $relese, 'type' => 'github'];
         } elseif ($file) {
             //If the Product is Downloaded from FileSystem
-            $fileName = $file->file;
-            $relese = Attach::download('products/'.$fileName);
-
-            return $relese;
+            return $this->stampingService->downloadResponseFor($file, $product, 'products/'.$file->file);
         }
     }
 
-    public function getReleaseAdmin($owner, $repository, $file)
+    public function getReleaseAdmin($owner, $repository, $file, Product $product)
     {
         if ($owner && $repository) {
             $github_controller = new \App\Http\Controllers\Github\GithubController();
@@ -247,13 +227,7 @@ class BaseProductController extends ExtendedBaseProductController
 
             return ['release' => $relese, 'type' => 'github'];
         } elseif ($file->file) {
-            // $relese = storage_path().'\products'.'\\'.$file->file;
-            //    $relese = '/home/faveo/products/'.$file->file;
-            $fileName = $file->file;
-
-            $relese = Attach::download('products/'.$fileName);
-
-            return $relese;
+            return $this->stampingService->downloadResponseFor($file, $product, 'products/'.$file->file);
         }
     }
 
@@ -272,7 +246,6 @@ class BaseProductController extends ExtendedBaseProductController
             };
 
             $file = ProductUpload::where('product_id', $id)
-                ->select('file')
                 ->where('is_private', 0)
                 ->where('is_restricted', 0)
                 ->where('release_type', $releaseType)
@@ -280,7 +253,7 @@ class BaseProductController extends ExtendedBaseProductController
 
             $permissions = LicensePermissionsController::getPermissionsForProduct($id);
             if ($permissions['downloadPermission'] == 1) {
-                $relese = $this->getReleaseAdmin($owner, $repository, $file);
+                $relese = $this->getReleaseAdmin($owner, $repository, $file, $product);
 
                 return $relese;
             }

--- a/app/Http/Controllers/Product/BaseProductController.php
+++ b/app/Http/Controllers/Product/BaseProductController.php
@@ -257,7 +257,7 @@ class BaseProductController extends ExtendedBaseProductController
         }
     }
 
-    public function downloadProductAdmin($id, $release = "official")
+    public function downloadProductAdmin($id, $release = 'official')
     {
         try {
             $product = Product::findOrFail($id);

--- a/app/Http/Controllers/Product/BaseProductController.php
+++ b/app/Http/Controllers/Product/BaseProductController.php
@@ -257,24 +257,27 @@ class BaseProductController extends ExtendedBaseProductController
         }
     }
 
-    public function downloadProductAdmin($id, $beta = 1)
+    public function downloadProductAdmin($id, $release = "official")
     {
         try {
             $product = Product::findOrFail($id);
             $type = $product->type;
             $owner = $product->github_owner;
             $repository = $product->github_repository;
-            if ($beta) {
-                $file = ProductUpload::where('product_id', '=', $id)->select('file')
-                    ->orderBy('created_at', 'desc')
-                    ->first();
-            } else {
-                $file = ProductUpload::where('product_id', '=', $id)->
-                    where('is_pre_release', 0)
-                    ->select('file')
-                    ->orderBy('created_at', 'desc')
-                    ->first();
-            }
+
+            $releaseType = match ($release) {
+                'beta' => 'beta',
+                'rc' => 'pre_release',
+                default => 'official',
+            };
+
+            $file = ProductUpload::where('product_id', $id)
+                ->select('file')
+                ->where('is_private', 0)
+                ->where('is_restricted', 0)
+                ->where('release_type', $releaseType)
+                ->orderBy('created_at', 'desc')->first();
+
             $permissions = LicensePermissionsController::getPermissionsForProduct($id);
             if ($permissions['downloadPermission'] == 1) {
                 $relese = $this->getReleaseAdmin($owner, $repository, $file);

--- a/app/Http/Controllers/Product/ExtendedBaseProductController.php
+++ b/app/Http/Controllers/Product/ExtendedBaseProductController.php
@@ -197,7 +197,7 @@ class ExtendedBaseProductController extends Controller
         }
     }
 
-    public function adminDownload($id, $invoice = '', $api = false, $release = "official")
+    public function adminDownload($id, $invoice = '', $api = false, $release = 'official')
     {
         $product = Product::where('id', $id)->get();
         $product = $product->toArray();

--- a/app/Http/Controllers/Product/ExtendedBaseProductController.php
+++ b/app/Http/Controllers/Product/ExtendedBaseProductController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Product;
 
-use App\Facades\Attach;
 use App\Http\Controllers\Controller;
 use App\Model\Common\StatusSetting;
 use App\Model\Order\Invoice;
@@ -12,7 +11,6 @@ use App\Model\Product\ProductUpload;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ExtendedBaseProductController extends Controller
 {
@@ -233,29 +231,15 @@ class ExtendedBaseProductController extends Controller
                     }
                 }
                 $release = $this->downloadProductAdmin($id, $release);
-                $name = Product::where('id', $id)->value('name');
-                if (isS3Enabled()) {
-                    if (! Attach::exists('products/'.explode('?', urldecode(basename($release)))[0])) {
-                        return redirect('my-orders')->with('fails', __('message.file_not_exist'));
-                    }
 
-                    return downloadExternalFile($release, $name);
-                } else {
-                    if (! $release instanceof \Symfony\Component\HttpFoundation\StreamedResponse) {
-                        return redirect('my-orders')->with('fails', \Lang::get('message.file_not_exist'));
-                    }
-                    $customFileName = "{$name}.zip";
-
-                    $release->headers->set(
-                        'Content-Disposition',
-                        $release->headers->makeDisposition(
-                            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                            $customFileName
-                        )
-                    );
-
-                    return $release;
+                // The stamping service always returns a local, ready-to-send
+                // file response (S3 or not — the file has to be copied and
+                // stamped locally either way).
+                if (! $release instanceof \Symfony\Component\HttpFoundation\Response) {
+                    return redirect('my-orders')->with('fails', \Lang::get('message.file_not_exist'));
                 }
+
+                return $release;
             } else {
                 throw new \Exception(\Lang::get('message.no_permission_for_action'));
             }

--- a/app/Http/Controllers/Product/ExtendedBaseProductController.php
+++ b/app/Http/Controllers/Product/ExtendedBaseProductController.php
@@ -197,7 +197,7 @@ class ExtendedBaseProductController extends Controller
         }
     }
 
-    public function adminDownload($id, $invoice = '', $api = false, $beta = 1)
+    public function adminDownload($id, $invoice = '', $api = false, $release = "official")
     {
         $product = Product::where('id', $id)->get();
         $product = $product->toArray();
@@ -232,7 +232,7 @@ class ExtendedBaseProductController extends Controller
                         }, $fileName);
                     }
                 }
-                $release = $this->downloadProductAdmin($id, $beta);
+                $release = $this->downloadProductAdmin($id, $release);
                 $name = Product::where('id', $id)->value('name');
                 if (isS3Enabled()) {
                     if (! Attach::exists('products/'.explode('?', urldecode(basename($release)))[0])) {

--- a/app/Http/Controllers/Product/ProductController.php
+++ b/app/Http/Controllers/Product/ProductController.php
@@ -21,6 +21,7 @@ use App\Model\Product\Product;
 use App\Model\Product\ProductGroup;
 use App\Model\Product\ProductUpload;
 use App\Model\Product\Subscription;
+use App\Services\Product\ProductBundleStampingService;
 use App\Traits\Upload\ChunkUpload;
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;
@@ -57,6 +58,8 @@ class ProductController extends BaseProductController
     public $tax_class;
 
     public $product_upload;
+
+    public ProductBundleStampingService $stampingService;
 
     public function __construct()
     {
@@ -101,6 +104,8 @@ class ProductController extends BaseProductController
 
         $license = new LicenseController();
         $this->licensing = $license;
+
+        $this->stampingService = new ProductBundleStampingService();
     }
 
     /**
@@ -640,10 +645,10 @@ class ProductController extends BaseProductController
             $repository = $product->github_repository;
             $file = $this->product_upload
                 ->where('product_id', '=', $uploadid)
-                ->where('id', $version_id)->select('file')->first();
+                ->where('id', $version_id)->first();
             $order = Order::where('invoice_id', '=', $invoice_id)->first();
             $order_id = $order->id;
-            $relese = $this->getRelease($owner, $repository, $order_id, $file);
+            $relese = $this->getRelease($owner, $repository, $order_id, $file, $product);
 
             return $relese;
         } catch (\Exception $e) {

--- a/app/Http/Controllers/Product/ProductController.php
+++ b/app/Http/Controllers/Product/ProductController.php
@@ -345,12 +345,13 @@ class ProductController extends BaseProductController
         }
 
         try {
+            $productKey = null;
             $licenseStatus = StatusSetting::pluck('license_status')->first();
             if ($licenseStatus) { //If License Setting Status is on,Add Product to the License Manager
                 $addProductToLicensing = $this->licensing->addNewProduct($input['name'], $input['product_sku']);
                 $product_id = $this->licensing->searchProductId($input['product_sku']);
                 $updateCont = new \App\Http\Controllers\AutoUpdate\AutoUpdateController();
-                $addProductToLicensing = $updateCont->addNewProductToAUS($product_id, $input['name'], $input['product_sku']);
+                $productKey = $updateCont->addNewProductToAUS($product_id, $input['name'], $input['product_sku']);
             }
             if ($request->hasFile('image')) {
                 $image = Attach::put('common/images/', $request->file('image'), null, true);
@@ -364,6 +365,9 @@ class ProductController extends BaseProductController
             $data = $request->except(['image', 'file']);
             if (! empty($product_id)) {
                 $data['id'] = $product_id;
+            }
+            if (! empty($productKey)) {
+                $data['product_key'] = $productKey;
             }
             $this->product->fill($data)->save();
 

--- a/app/Http/Controllers/User/SoftDeleteController.php
+++ b/app/Http/Controllers/User/SoftDeleteController.php
@@ -127,7 +127,8 @@ class SoftDeleteController extends ClientController
                             $isCloudDeleted = Subscription::where('order_id', $tenant)
                                 ->where('is_deleted', 1)
                                 ->exists();
-                            if ($installation_path && ! $isCloudDeleted) {
+                            $tenantProductId = \App\Model\Order\Order::where('id', $tenant)->value('product');
+                            if ($installation_path && ! $isCloudDeleted && in_array($tenantProductId, cloudPopupProducts())) {
                                 event(new UserOrderDelete($installation_path, $tenant));
                             }
                         }

--- a/app/Model/Product/Product.php
+++ b/app/Model/Product/Product.php
@@ -29,6 +29,9 @@ class Product extends BaseModel
      *                       1 = Active — monthly/yearly subscription toggle is shown in the store
      *                       0 = Inactive — product is visible in the store but monthly/yearly toggle is hidden
      *                       --------------------------------------------------------------------------
+     * @property string|null $product_key
+     * @property string|null $apl_salt
+     * @property string|null $config_file_path
      */
     protected $fillable = ['id', 'name', 'description', 'short_description', 'type', 'group', 'file', 'image', 'require_domain', 'category',
         'can_modify_agent',  'can_modify_quantity', 'show_agent', 'tax_apply', 'show_product_quantity', 'hidden',  'auto_terminate',
@@ -36,7 +39,7 @@ class Product extends BaseModel
         'no_auto_setup', 'shoping_cart_link', 'process_url', 'github_owner',
         'github_repository',
         'deny_after_subscription', 'version', 'parent', 'subscription', 'product_sku', 'perpetual_license', 'product_description', 'invoice_hidden',
-        'status', 'whatsapp_integration',
+        'status', 'whatsapp_integration', 'product_key', 'apl_salt', 'config_file_path',
     ];
 
     protected $logName = 'product';

--- a/app/Services/Product/ProductBundleStampingService.php
+++ b/app/Services/Product/ProductBundleStampingService.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Services\Product;
+
+use App\Facades\Attach;
+use App\Model\Product\Product;
+use App\Model\Product\ProductUpload;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ZipArchive;
+
+/**
+ * Turns one canonical uploaded build into a specific product's own
+ * downloadable file, by writing that product's identity (product_key,
+ * a persistent salt, app name/version) into whatever destination path
+ * *that product itself* declares (Product::config_file_path). This lets
+ * one shared build — every plugin folder intact — be sold as many
+ * differently-licensed products. Nothing is ever removed from the zip.
+ */
+class ProductBundleStampingService
+{
+    /**
+     * Stamps $targetProduct's identity into a local temp copy of the
+     * canonical build and returns that copy's path. Nothing is persisted
+     * back to storage — the caller owns the returned file and must delete
+     * it once done.
+     *
+     * @throws RuntimeException if the product has no product_key, or the
+     *                          canonical file can't be found/opened.
+     */
+    public function stampToLocalFile(string $canonicalFilePath, Product $targetProduct, string $version): string
+    {
+        if (empty($targetProduct->product_key)) {
+            // Nothing downstream can ever authenticate a build stamped with
+            // no key — refuse rather than silently ship an unusable artifact.
+            throw new RuntimeException("Product #{$targetProduct->id} ({$targetProduct->name}) has no product_key set — refusing to stamp a build for it.");
+        }
+
+        $localCopy = $this->copyToLocalTemp($canonicalFilePath);
+
+        try {
+            $this->stampZip($localCopy, $targetProduct, $version);
+        } catch (Throwable $e) {
+            // Don't leave a half-stamped (or never-stamped) copy behind in the
+            // system temp dir — this runs on every download, so a recurring
+            // failure here would otherwise accumulate real disk usage.
+            @unlink($localCopy);
+
+            throw $e;
+        }
+
+        return $localCopy;
+    }
+
+    /**
+     * Stamps a copy of $storagePath for $product and returns it as a
+     * ready-to-return file-download response (cleans up the temp file
+     * after sending).
+     *
+     * @throws RuntimeException if stamping fails; callers decide what
+     *                          that looks like in their own response.
+     */
+    public function downloadResponseFor(ProductUpload $version, Product $product, string $storagePath): Response
+    {
+        $localStampedPath = $this->stampToLocalFile($storagePath, $product, $version->version);
+
+        $extension = pathinfo($storagePath, PATHINFO_EXTENSION);
+        $safeVersion = preg_replace('/[^A-Za-z0-9.]+/', '-', $version->version);
+        $downloadName = Str::slug($product->name).'-'.$safeVersion.'.'.$extension;
+
+        return response()->download($localStampedPath, $downloadName)->deleteFileAfterSend();
+    }
+
+    /**
+     * Copies an Attach-stored file (local disk or remote/S3) to a local
+     * temp path so ZipArchive has a real filesystem path to work with.
+     *
+     * @throws RuntimeException if the source file doesn't exist or the
+     *                          temp file can't be allocated/opened.
+     */
+    private function copyToLocalTemp(string $canonicalFilePath): string
+    {
+        if (! Attach::exists($canonicalFilePath)) {
+            throw new RuntimeException("Canonical build not found: {$canonicalFilePath}");
+        }
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'product_bundle_');
+
+        if ($tempPath === false) {
+            throw new RuntimeException('Unable to allocate a local temp file for stamping.');
+        }
+
+        // Open the destination before the (potentially remote/S3) source
+        // stream, so a local fopen failure never leaves a source stream open.
+        $destination = fopen($tempPath, 'wb');
+
+        if ($destination === false) {
+            throw new RuntimeException("Unable to open temp file for writing: {$tempPath}");
+        }
+
+        $source = Attach::readStream($canonicalFilePath);
+        stream_copy_to_stream($source, $destination);
+        fclose($source);
+        fclose($destination);
+
+        return $tempPath;
+    }
+
+    /**
+     * Does the actual in-place stamping of the local zip copy. Everything
+     * else in the zip, including every bundled plugin folder, is left
+     * untouched.
+     */
+    private function stampZip(string $localZipPath, Product $targetProduct, string $version): void
+    {
+        $zip = new ZipArchive;
+
+        if ($zip->open($localZipPath) !== true) {
+            throw new RuntimeException("Unable to open canonical build for stamping: {$localZipPath}");
+        }
+
+        try {
+            if (! empty($targetProduct->config_file_path)) {
+                $this->assertSafeZipEntryPath($targetProduct->config_file_path);
+                $zip->addFromString($targetProduct->config_file_path, $this->buildFaveoConfig($targetProduct, $version));
+            }
+        } finally {
+            $zip->close();
+        }
+    }
+
+    /**
+     * Refuses an absolute path or a `..` traversal segment in a product's
+     * declared config_file_path — the one place every write actually
+     * happens, and the only guard that covers a direct-DB/tinker write
+     * that bypasses admin-form validation entirely.
+     */
+    private function assertSafeZipEntryPath(string $path): void
+    {
+        if (str_starts_with($path, '/') || str_contains($path, '..')) {
+            throw new RuntimeException("Refusing to stamp an unsafe zip-internal path: {$path}");
+        }
+    }
+
+    /**
+     * Builds the full contents of a product's config file, written
+     * wherever that product's own config_file_path points.
+     */
+    private function buildFaveoConfig(Product $targetProduct, string $version): string
+    {
+        $lines = [
+            'APL_SALT='.$this->getAplSalt($targetProduct),
+            'PRODUCT_KEY='.$targetProduct->product_key,
+            'APP_NAME='.$targetProduct->name,
+            'APP_VERSION='.$version,
+            'PRODUCT_ID='.$targetProduct->id,
+            'LICENSE_MODE=DATABASE',
+            '',
+        ];
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Returns $targetProduct's APL_SALT, generating and persisting one
+     * the first time it's needed. Must never change for a product once
+     * shipped, so this reuses the stored value if there already is one.
+     */
+    private function getAplSalt(Product $targetProduct): string
+    {
+        if (! empty($targetProduct->apl_salt)) {
+            return $targetProduct->apl_salt;
+        }
+
+        $salt = bin2hex(random_bytes(8));
+        $targetProduct->update(['apl_salt' => $salt]);
+
+        return $salt;
+    }
+}

--- a/app/Services/Product/ProductBundleStampingService.php
+++ b/app/Services/Product/ProductBundleStampingService.php
@@ -156,6 +156,7 @@ class ProductBundleStampingService
             'APP_NAME='.$targetProduct->name,
             'APP_VERSION='.$version,
             'PRODUCT_ID='.$targetProduct->id,
+            'PRODUCT_NAME_FOR_AUTO_UPDATE='.$targetProduct->name,
             'LICENSE_MODE=DATABASE',
             '',
         ];

--- a/database/migrations/2026_08_12_000000_add_product_bundle_stamping_columns_to_products_table.php
+++ b/database/migrations/2026_08_12_000000_add_product_bundle_stamping_columns_to_products_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table): void {
+            // The key this product's own build authenticates itself with, and
+            // the salt/config path used to stamp that identity into a shared
+            // canonical zip on every download (see ProductBundleStampingService).
+            $table->string('product_key')->nullable();
+            $table->string('apl_salt')->nullable();
+            $table->string('config_file_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table): void {
+            $table->dropColumn(['product_key', 'apl_salt', 'config_file_path']);
+        });
+    }
+};

--- a/lang/en/message.php
+++ b/lang/en/message.php
@@ -291,6 +291,8 @@ return [
     'tick-to-apply-compund-taxing' => 'Tick to apply compund taxing',
     'deny_after_subscription' => 'Deny after subscription',
     'sku' => 'Product SKU (Stock Keeping Unit)',
+    'product_key' => 'Product Key',
+    'config_file_path' => 'Config File Path (inside the build zip)',
     'perpetual_license' => 'Perpetual License',
     'perpetual_license-detail' => 'If selected ,the license expiration date would not be generated, ie, the product can be used perpetually',
     /*

--- a/resources/views/themes/default1/front/clients/delete-cloud-popup.blade.php
+++ b/resources/views/themes/default1/front/clients/delete-cloud-popup.blade.php
@@ -1,14 +1,14 @@
 
-<button class="btn btn-light-scale-2 btn-sm text-dark open-deleteTenantDialog" data-toggle="modal" data-target="#deleteConfirmationModal">
+<button class="btn btn-light-scale-2 btn-sm text-dark open-deleteTenantDialog" data-toggle="modal" data-target="#deleteConfirmationModal-{{ $orderNumber }}">
     <i class="fa fa-trash" data-toggle="tooltip" title="{{ __('message.click_cloud')}}"></i>&nbsp;
 </button>
 
 <!-- Modal -->
-<div class="modal fade" id="deleteConfirmationModal" tabindex="-1" role="dialog" aria-labelledby="deleteConfirmationModalLabel" aria-hidden="true">
+<div class="modal fade" id="deleteConfirmationModal-{{ $orderNumber }}" tabindex="-1" role="dialog" aria-labelledby="deleteConfirmationModalLabel-{{ $orderNumber }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
              <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel" style="font-size: large;">{{ __('message.delete_confirm')}}</h5>
+        <h5 class="modal-title" id="deleteConfirmationModalLabel-{{ $orderNumber }}" style="font-size: large;">{{ __('message.delete_confirm')}}</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/resources/views/themes/default1/product/product/create.blade.php
+++ b/resources/views/themes/default1/product/product/create.blade.php
@@ -386,16 +386,6 @@
                                 </li>
 
                                 <li>
-                                    <div class="form-group {{ $errors->has('product_key') ? 'has-error' : '' }}">
-                                        {!! html()->label(trans('message.product_key'), 'product_key') !!}
-                                        {!! html()->text('product_key')->class('form-control'.($errors->has('product_key') ? ' is-invalid' : ''))->id('product_key') !!}
-                                        @error('product_key')
-                                        <span class="error-message"> {{$message}}</span>
-                                        @enderror
-                                    </div>
-                                </li>
-
-                                <li>
                                     <div class="form-group {{ $errors->has('config_file_path') ? 'has-error' : '' }}">
                                         {!! html()->label(trans('message.config_file_path'), 'config_file_path') !!}
                                         {!! html()->text('config_file_path')->class('form-control'.($errors->has('config_file_path') ? ' is-invalid' : ''))->id('config_file_path') !!}

--- a/resources/views/themes/default1/product/product/create.blade.php
+++ b/resources/views/themes/default1/product/product/create.blade.php
@@ -386,6 +386,26 @@
                                 </li>
 
                                 <li>
+                                    <div class="form-group {{ $errors->has('product_key') ? 'has-error' : '' }}">
+                                        {!! html()->label(trans('message.product_key'), 'product_key') !!}
+                                        {!! html()->text('product_key')->class('form-control'.($errors->has('product_key') ? ' is-invalid' : ''))->id('product_key') !!}
+                                        @error('product_key')
+                                        <span class="error-message"> {{$message}}</span>
+                                        @enderror
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="form-group {{ $errors->has('config_file_path') ? 'has-error' : '' }}">
+                                        {!! html()->label(trans('message.config_file_path'), 'config_file_path') !!}
+                                        {!! html()->text('config_file_path')->class('form-control'.($errors->has('config_file_path') ? ' is-invalid' : ''))->id('config_file_path') !!}
+                                        @error('config_file_path')
+                                        <span class="error-message"> {{$message}}</span>
+                                        @enderror
+                                    </div>
+                                </li>
+
+                                <li>
                                     <div class="form-group {{ $errors->has('parent') ? 'has-error' : '' }}">
                                         <!-- last name -->
                                         {!! html()->label(trans('message.parent'), 'parent') !!}
@@ -704,7 +724,7 @@
                                         <select id="Tax" placeholder="{{ __('message.select_taxes') }}" name="tax[]" style="width:500px;" class="select2 " multiple="multiple">
                                             <option></option>
                                             @foreach($taxes as $value)
-                                                <option value={{$value['id']}}>{{$value['name'].'('.$value['tax'][0]['name'].')'}}</option>
+                                                <option value={{$value['id']}}>{{$value['name'].(!empty($value['tax'][0]['name']) ? ' ('.$value['tax'][0]['name'].')' : '')}}</option>
                                             @endforeach
                                         </select>
 

--- a/resources/views/themes/default1/product/product/edit.blade.php
+++ b/resources/views/themes/default1/product/product/edit.blade.php
@@ -181,16 +181,6 @@
                                 </li>
 
                                 <li>
-                                    <div class="form-group {{ $errors->has('product_key') ? 'has-error' : '' }}">
-                                        {!! html()->label(trans('message.product_key'), 'product_key') !!}
-                                        {!! html()->text('product_key')->class('form-control'.($errors->has('product_key') ? ' is-invalid' : ''))->id('product_key') !!}
-                                        @error('product_key')
-                                        <span class="error-message"> {{$message}}</span>
-                                        @enderror
-                                    </div>
-                                </li>
-
-                                <li>
                                     <div class="form-group {{ $errors->has('config_file_path') ? 'has-error' : '' }}">
                                         {!! html()->label(trans('message.config_file_path'), 'config_file_path') !!}
                                         {!! html()->text('config_file_path')->class('form-control'.($errors->has('config_file_path') ? ' is-invalid' : ''))->id('config_file_path') !!}

--- a/resources/views/themes/default1/product/product/edit.blade.php
+++ b/resources/views/themes/default1/product/product/edit.blade.php
@@ -179,6 +179,26 @@
                                         @enderror
                                     </div>
                                 </li>
+
+                                <li>
+                                    <div class="form-group {{ $errors->has('product_key') ? 'has-error' : '' }}">
+                                        {!! html()->label(trans('message.product_key'), 'product_key') !!}
+                                        {!! html()->text('product_key')->class('form-control'.($errors->has('product_key') ? ' is-invalid' : ''))->id('product_key') !!}
+                                        @error('product_key')
+                                        <span class="error-message"> {{$message}}</span>
+                                        @enderror
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="form-group {{ $errors->has('config_file_path') ? 'has-error' : '' }}">
+                                        {!! html()->label(trans('message.config_file_path'), 'config_file_path') !!}
+                                        {!! html()->text('config_file_path')->class('form-control'.($errors->has('config_file_path') ? ' is-invalid' : ''))->id('config_file_path') !!}
+                                        @error('config_file_path')
+                                        <span class="error-message"> {{$message}}</span>
+                                        @enderror
+                                    </div>
+                                </li>
                                 <li>
                                     <div class="form-group {{ $errors->has('parent') ? 'has-error' : '' }}">
                                         <!-- last name -->
@@ -434,7 +454,7 @@
                                         <select id="editTax" placeholder="{{ __('message.select_taxes') }}" name="tax[]" style="width:500px;" class="select2" multiple="true">
 
                                             @foreach($taxes as $value)
-                                                <option value={{$value['id']}} <?php echo (in_array($value['id'], $savedTaxes)) ?  "selected" : "" ;  ?>>{{$value['name'].'('.$value['tax'][0]['name'].')'}}</option>
+                                                <option value={{$value['id']}} <?php echo (in_array($value['id'], $savedTaxes)) ?  "selected" : "" ;  ?>>{{$value['name'].(!empty($value['tax'][0]['name']) ? ' ('.$value['tax'][0]['name'].')' : '')}}</option>
                                             @endforeach
                                         </select>
 

--- a/tests/Unit/AutoUpdate/AutoUpdateControllerTest.php
+++ b/tests/Unit/AutoUpdate/AutoUpdateControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\AutoUpdate;
+
+use App\ApiKey;
+use App\Http\Controllers\AutoUpdate\AutoUpdateController;
+use Illuminate\Support\Facades\Cache;
+use Tests\DBTestCase;
+
+class AutoUpdateControllerTest extends DBTestCase
+{
+    public function test_add_new_product_to_aus_returns_the_generated_product_key(): void
+    {
+        // Empty license config -> LicenseService::getUrl()/getApiKeySecret() are ''.
+        // Pre-seed a live, non-expiring cached token under that same '' config so
+        // getValidToken() short-circuits and no real HTTP call to a license
+        // manager is ever made by this test.
+        ApiKey::create([]);
+        Cache::put('license_response_'.md5(''), [
+            'access_token' => 'fake-token',
+            'stored_at' => now()->timestamp,
+            'expires_in' => 3600,
+        ]);
+
+        $key = (new AutoUpdateController())->addNewProductToAUS(1, 'Test Product', 'TEST-SKU');
+
+        // This is the actual bug being fixed: the method used to fall off the
+        // end of its try block and implicitly return null, so the key it just
+        // sent to the License Manager was never available to persist locally.
+        $this->assertNotEmpty($key);
+        $this->assertSame(16, strlen($key));
+    }
+}

--- a/tests/Unit/Client/Product/ProductEditTaxDisplayTest.php
+++ b/tests/Unit/Client/Product/ProductEditTaxDisplayTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Client\Product;
+
+use App\Model\Payment\TaxClass;
+use App\Model\Product\Product;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\DBTestCase;
+
+class ProductEditTaxDisplayTest extends DBTestCase
+{
+    use DatabaseTransactions;
+
+    public function test_edit_page_renders_when_a_tax_class_has_no_tax_rows(): void
+    {
+        $this->withoutMiddleware(\App\Http\Middleware\Install::class);
+        $this->getLoggedInUser('admin');
+
+        $product = Product::factory()->create();
+        // The exact real-world condition that crashed both blade views:
+        // a tax class with zero related `tax` rows.
+        TaxClass::create(['name' => 'Standard-No-Rate']);
+
+        $response = $this->get("/products/{$product->id}/edit");
+
+        $response->assertStatus(200);
+        $response->assertSee('Standard-No-Rate', false);
+    }
+}

--- a/tests/Unit/Services/Product/ProductBundleStampingServiceTest.php
+++ b/tests/Unit/Services/Product/ProductBundleStampingServiceTest.php
@@ -102,6 +102,7 @@ class ProductBundleStampingServiceTest extends TestCase
         $config = $this->readZipEntry($resultPath, 'storage/faveoconfig.ini');
         $this->assertStringContainsString('PRODUCT_KEY=COREKEY123', $config);
         $this->assertStringContainsString('APP_NAME=Core Product', $config);
+        $this->assertStringContainsString('PRODUCT_NAME_FOR_AUTO_UPDATE=Core Product', $config);
         $this->assertStringContainsString('APP_VERSION=1.2.3', $config);
         $this->assertStringContainsString('PRODUCT_ID=42', $config);
         $this->assertStringContainsString('LICENSE_MODE=DATABASE', $config);

--- a/tests/Unit/Services/Product/ProductBundleStampingServiceTest.php
+++ b/tests/Unit/Services/Product/ProductBundleStampingServiceTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Tests\Unit\Services\Product;
+
+use App\Facades\Attach;
+use App\Model\Product\Product;
+use App\Model\Product\ProductUpload;
+use App\Services\Product\ProductBundleStampingService;
+use Mockery;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Tests\TestCase;
+use ZipArchive;
+
+class ProductBundleStampingServiceTest extends TestCase
+{
+    private ProductBundleStampingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ProductBundleStampingService();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_throws_when_product_has_no_product_key(): void
+    {
+        $product = $this->makeProduct(['product_key' => null]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has no product_key set');
+
+        $this->service->stampToLocalFile('some/path.zip', $product, '1.0.0');
+    }
+
+    public function test_throws_when_canonical_file_is_not_found(): void
+    {
+        $product = $this->makeProduct();
+        Attach::shouldReceive('exists')->once()->andReturn(false);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Canonical build not found');
+
+        $this->service->stampToLocalFile('missing/path.zip', $product, '1.0.0');
+    }
+
+    public function test_throws_when_config_file_path_contains_a_traversal_segment(): void
+    {
+        $product = $this->makeProduct(['config_file_path' => '../evil.ini']);
+        $sourceZip = $this->makeZip(['storage/faveoconfig.ini' => '']);
+        $this->stubAttachToServe($sourceZip);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('unsafe zip-internal path');
+
+            $this->service->stampToLocalFile('canonical/path.zip', $product, '1.0.0');
+        } finally {
+            @unlink($sourceZip);
+        }
+    }
+
+    public function test_stamping_failure_cleans_up_the_local_temp_copy(): void
+    {
+        $product = $this->makeProduct();
+        $garbageSource = tempnam(sys_get_temp_dir(), 'garbage_source_');
+        file_put_contents($garbageSource, 'not a real zip');
+        $this->stubAttachToServe($garbageSource);
+
+        $before = glob(sys_get_temp_dir().'/product_bundle_*');
+
+        try {
+            $this->service->stampToLocalFile('some/path.zip', $product, '1.0.0');
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('Unable to open canonical build for stamping', $e->getMessage());
+        }
+
+        $after = glob(sys_get_temp_dir().'/product_bundle_*');
+        $this->assertSame($before, $after);
+
+        @unlink($garbageSource);
+    }
+
+    public function test_stamps_config_and_leaves_other_zip_entries_untouched(): void
+    {
+        $product = $this->makeProduct(['id' => 42, 'product_key' => 'COREKEY123', 'name' => 'Core Product', 'config_file_path' => 'storage/faveoconfig.ini']);
+        $sourceZip = $this->makeZip([
+            'storage/faveoconfig.ini' => "APL_SALT=old\nPRODUCT_KEY=old\n",
+            'app/Plugins/UnrelatedPlugin/config.php' => "<?php\nreturn ['product_id' => 1, 'product_key' => 'OLD', 'version' => '0.0.1'];\n",
+        ]);
+        $this->stubAttachToServe($sourceZip);
+
+        $resultPath = $this->service->stampToLocalFile('canonical/path.zip', $product, '1.2.3');
+
+        $config = $this->readZipEntry($resultPath, 'storage/faveoconfig.ini');
+        $this->assertStringContainsString('PRODUCT_KEY=COREKEY123', $config);
+        $this->assertStringContainsString('APP_NAME=Core Product', $config);
+        $this->assertStringContainsString('APP_VERSION=1.2.3', $config);
+        $this->assertStringContainsString('PRODUCT_ID=42', $config);
+        $this->assertStringContainsString('LICENSE_MODE=DATABASE', $config);
+        $this->assertMatchesRegularExpression('/^APL_SALT=[0-9a-f]{16}$/m', $config);
+
+        // Nothing is ever removed from the zip — the unrelated plugin folder
+        // ships exactly as it was in the canonical build.
+        $unrelatedPlugin = $this->readZipEntry($resultPath, 'app/Plugins/UnrelatedPlugin/config.php');
+        $this->assertStringContainsString("'product_key' => 'OLD'", $unrelatedPlugin);
+
+        @unlink($resultPath);
+        @unlink($sourceZip);
+    }
+
+    public function test_apl_salt_is_generated_once_and_reused_on_subsequent_stamps(): void
+    {
+        $product = $this->makeProduct(['product_key' => 'COREKEY456', 'config_file_path' => 'storage/faveoconfig.ini']);
+        $sourceZip = $this->makeZip(['storage/faveoconfig.ini' => '']);
+        $this->stubAttachToServe($sourceZip);
+
+        $first = $this->service->stampToLocalFile('canonical/path.zip', $product, '1.0.0');
+        $firstSalt = $product->apl_salt;
+
+        $second = $this->service->stampToLocalFile('canonical/path.zip', $product, '1.0.1');
+        $secondSalt = $product->apl_salt;
+
+        $this->assertNotEmpty($firstSalt);
+        $this->assertSame($firstSalt, $secondSalt);
+
+        @unlink($first);
+        @unlink($second);
+        @unlink($sourceZip);
+    }
+
+    public function test_download_response_for_returns_a_downloadable_response(): void
+    {
+        $product = $this->makeProduct(['product_key' => 'DLKEY', 'name' => 'My Product']);
+        $version = new ProductUpload(['file' => 'release-1.0.0.zip', 'version' => '1.0.0']);
+
+        $sourceZip = $this->makeZip(['storage/faveoconfig.ini' => '']);
+        $this->stubAttachToServe($sourceZip);
+
+        $response = $this->service->downloadResponseFor($version, $product, 'products/release-1.0.0.zip');
+
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertStringContainsString('my-product-1.0.0.zip', (string) $response->headers->get('Content-Disposition'));
+
+        // deleteFileAfterSend() only fires on a real HTTP send, which never
+        // happens here — clean up the stamped output file ourselves.
+        @unlink($response->getFile()->getPathname());
+        @unlink($sourceZip);
+    }
+
+    /**
+     * Builds a Product with update() stubbed to persist in-memory instead of
+     * hitting a real DB — this repo's tests mock the model layer rather than
+     * writing to a real database.
+     */
+    private function makeProduct(array $attributes = []): Product
+    {
+        $product = Mockery::mock(Product::class)->makePartial();
+        $product->forceFill(array_merge([
+            'id' => 1,
+            'name' => 'Test Product',
+            'product_key' => 'TESTKEY',
+        ], $attributes));
+
+        $product->shouldReceive('update')->andReturnUsing(function (array $attrs) use ($product) {
+            $product->forceFill($attrs);
+
+            return true;
+        })->byDefault();
+
+        return $product;
+    }
+
+    /**
+     * @param  array<string, string>  $entries
+     */
+    private function makeZip(array $entries): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'source_build_');
+
+        $zip = new ZipArchive;
+        $zip->open($path, ZipArchive::OVERWRITE);
+        foreach ($entries as $name => $content) {
+            $zip->addFromString($name, $content);
+        }
+        $zip->close();
+
+        return $path;
+    }
+
+    private function readZipEntry(string $zipPath, string $entryName): ?string
+    {
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        $content = $zip->getFromName($entryName);
+        $zip->close();
+
+        return $content === false ? null : $content;
+    }
+
+    private function stubAttachToServe(string $localZipPath): void
+    {
+        Attach::shouldReceive('exists')->andReturn(true);
+        Attach::shouldReceive('readStream')->andReturnUsing(fn () => fopen($localZipPath, 'rb'));
+    }
+}


### PR DESCRIPTION
# Product Download & Release Channel Updates

## 1. Product Downloads by Release Channel

* Product downloads from the **Admin Panel** or **API** now select the file based on the release channel.
* Supported release values:

  * `release=beta`
  * `release=rc`
  * `release=official`
* The default release channel is **official**.
* This replaces the previous behavior of selecting between **latest** and **not-beta**.

## 2. Download by Order Number API

The following API now supports the `release` parameter:

```text
download/faveo?order_number=...&serial_key=...&release=...
```

### QA Verification

* Verify that `release=beta`, `release=rc`, and `release=official` return the correct release file.
* Verify that the **order number and serial key must still match** to download a file.
* Verify that incorrect order numbers or serial keys are rejected.
* Verify that the default behavior returns the **official** release when `release` is not provided.

## 3. Per-Product Config Stamping on Download

* Products can now have:

  * **Config File Path**
* These are new fields available during product creation/editing.
* When a product is downloaded:

  * Its config file is written into the ZIP at the configured path.
  * The config contains that product's own Product Key.
* This must work even when multiple products share the same uploaded build file.

### QA Verification

* [ ] Download two different products that point to the **same uploaded build file**.
* [ ] Verify that each download generates a separate ZIP.
* [ ] Verify that each ZIP contains the correct config file path.
* [ ] Verify that each ZIP contains the **correct Product Key for that product**.
* [ ] Verify there is **no cross-contamination** between products.
* [ ] Verify that the download **fails cleanly** and does not ship an invalid or incomplete file.
